### PR TITLE
Update dependency on phpmyadmin/sql-parser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Dependencies
 - `udan11's SqlParser`__, which is used by `phpMyAdmin`__
 
 __ http://pear.php.net/package/Console_CommandLine
-__ https://github.com/udan11/sql-parser
+__ https://github.com/phpmyadmin/sql-parser
 __ https://www.phpmyadmin.net/
 
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "bin": ["bin/php-sqllint"],
     "require": {
-        "udan11/sql-parser": "^3.0",
+        "phpmyadmin/sql-parser": "^3.0",
         "pear/console_commandline": "^1.2"
     },
     "homepage": "http://cweiske.de/php-sqllint.htm",


### PR DESCRIPTION
The udan11/sql-parser package is marked as abandoned,
with the phpmyadmin/sql-parser being recommended.

Also update the link to GitHub in ReadMe.

Closes #4.
